### PR TITLE
Add function prototype for perf_event_open

### DIFF
--- a/timing-harness/rdpmc.h
+++ b/timing-harness/rdpmc.h
@@ -23,13 +23,16 @@
 extern "C" {
 #endif
 
+int perf_event_open(struct perf_event_attr *attr, pid_t pid,
+		    int cpu, int group_fd, unsigned long flags);
+
 struct rdpmc_ctx {
 	int fd;
 	struct perf_event_mmap_page *buf;
 };
 
 int rdpmc_open(unsigned counter, struct rdpmc_ctx *ctx);
-int rdpmc_open_attr(struct perf_event_attr *attr, struct rdpmc_ctx *ctx, 
+int rdpmc_open_attr(struct perf_event_attr *attr, struct rdpmc_ctx *ctx,
 		    struct rdpmc_ctx *leader_ctx);
 void rdpmc_close(struct rdpmc_ctx *ctx);
 unsigned long long rdpmc_read(struct rdpmc_ctx *ctx);


### PR DESCRIPTION
This pull request adds a missing prototype for `perf_event_open`.

Without this, the following warning occurs when running `make`:

```
rdpmc.c: In function ‘rdpmc_open_attr’:
rdpmc.c:85:12: warning: implicit declaration of function ‘perf_event_open’ [-Wimplicit-function-declaration]
   85 |  ctx->fd = perf_event_open(attr, 0, -1,
```